### PR TITLE
feat: Adds a CLI to convert projects to use gha-runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install '.[test]'
+          python -m pip install '.[test,convert]'
 
       - name: List versions
         run: |
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: |
           cd tests/
-          pytest -v --cov=gha_runner --cov-report=xml --color=yes .
+          pytest -v --cov=gha_runner --cov=gha_runner_convert --cov-report=xml --color=yes .
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ test = [
     "pytest-cov",
     "moto[ec2]",
 ]
+convert = [
+    "ruamel.yaml",
+    "click",
+]
 
 [build-system]
 # We are not going to add versioningit at this time
@@ -21,6 +25,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+include = ["gha_runner", "gha_runner_convert"]
 
 [tool.setuptools.package-data]
 gha_runner = ["*.templ", "templates/*.templ"]

--- a/src/gha_runner_convert/__main__.py
+++ b/src/gha_runner_convert/__main__.py
@@ -1,0 +1,127 @@
+from ruamel.yaml import YAML
+from collections import OrderedDict
+import click
+
+
+def before_job(
+    role: str, region: str, ami: str, instance_type: str, home_dir: str
+):
+    return {
+        "start-aws-runner": {
+            "runs-on": "ubuntu-latest",
+            "permissions": {
+                "id-token": "write",
+                "contents": "read",
+            },
+            "outputs": {
+                "mapping": "${{ steps.aws-start.outputs.mapping }}",
+                "instances": "${{ steps.aws-start.outputs.instances }}",
+            },
+            "steps": [
+                {
+                    "name": "Configure AWS credentials",
+                    "uses": "aws-actions/configure-aws-credentials@v4",
+                    "with": {
+                        "role-to-assume": role,
+                        "aws-region": region,
+                    },
+                },
+                {
+                    "name": "Start AWS runner",
+                    "id": "aws-start",
+                    "uses": "omsf-eco-infra/gha-runner@v0.3.0",
+                    "with": {
+                        "provider": "aws",
+                        "action": "start",
+                        "aws_image_id": ami,
+                        "aws_instance_type": instance_type,
+                        "aws_region_name": region,
+                        "aws_home_dir": home_dir,
+                    },
+                    "env": {
+                        "GH_PAT": "${{ secrets.GH_PAT }}",
+                    },
+                },
+            ],
+        }
+    }
+
+
+def after_job(job: str, role: str, region: str):
+    return {
+        "stop-aws-runner": {
+            "runs-on": "ubuntu-latest",
+            "permissions": {
+                "id-token": "write",
+                "contents": "read",
+            },
+            "needs": ["start-aws-runner", job],
+            "if": "${{ always() }}",
+            "steps": [
+                {
+                    "name": "Configure AWS credentials",
+                    "uses": "aws-actions/configure-aws-credentials@v4",
+                    "with": {
+                        "role-to-assume": role,
+                        "aws-region": region,
+                    },
+                },
+                {
+                    "name": "Stop AWS runner",
+                    "uses": "omsf-eco-infra/gha-runner@v0.3.0",
+                    "with": {
+                        "provider": "aws",
+                        "action": "stop",
+                        "instance_mapping": "${{ needs.start-aws-runner.outputs.mapping }}",
+                        "aws_region_name": region,
+                    },
+                    "env": {
+                        "GH_PAT": "${{ secrets.GH_PAT }}",
+                    },
+                },
+            ],
+        }
+    }
+
+
+@click.command()
+@click.argument("input_file", type=click.File("r"))
+@click.option("--role", required=True, type=str, help="AWS IAM role to assume")
+@click.option("--region", required=True, type=str, help="AWS region")
+@click.option("--ami", required=True, type=str, help="AWS AMI ID")
+@click.option(
+    "--instance-type", required=True, type=str, help="AWS instance type"
+)
+@click.option("--home-dir", required=True, type=str, help="AWS home directory")
+def read_file(input_file, role, region, ami, instance_type, home_dir):
+    yaml = YAML()
+    yaml.default_flow_style = False
+    # yaml.preserve_quotes = True
+    data = yaml.load(input_file)
+    jobs = data.get("jobs", OrderedDict())
+    job_name = ""
+    for job in data["jobs"]:
+        job_name = job
+    new_job_list = OrderedDict()
+    before = before_job(role, region, ami, instance_type, home_dir)
+    after = after_job(job_name, role, region)
+    for k, v in jobs.items():
+        if k == job_name:
+            new_job_list.update(before)
+        v.update(
+            {
+                "runs-on": "${{ fromJSON(needs.start-aws-runner.outputs.instances) }}"
+            }
+        )
+        v["needs"] = ["start-aws-runner"]
+        new_job_list[k] = v
+        if k == job_name:
+            new_job_list.update(after)
+
+    data["jobs"] = dict(new_job_list)
+
+    yaml.dump(data, click.get_text_stream("stdout"))
+
+
+if __name__ == "__main__":
+    read_file()

--- a/src/gha_runner_convert/__main__.py
+++ b/src/gha_runner_convert/__main__.py
@@ -1,5 +1,4 @@
 from ruamel.yaml import YAML
-from collections import OrderedDict
 import click
 
 
@@ -98,11 +97,11 @@ def read_file(input_file, role, region, ami, instance_type, home_dir):
     yaml.default_flow_style = False
     # yaml.preserve_quotes = True
     data = yaml.load(input_file)
-    jobs = data.get("jobs", OrderedDict())
+    jobs = data.get("jobs", {})
     job_name = ""
     for job in data["jobs"]:
         job_name = job
-    new_job_list = OrderedDict()
+    new_job_list = {}
     before = before_job(role, region, ami, instance_type, home_dir)
     after = after_job(job_name, role, region)
     for k, v in jobs.items():

--- a/src/gha_runner_convert/__main__.py
+++ b/src/gha_runner_convert/__main__.py
@@ -104,6 +104,9 @@ def read_file(input_file, role, region, ami, instance_type, home_dir):
     new_job_list = {}
     before = before_job(role, region, ami, instance_type, home_dir)
     after = after_job(job_name, role, region)
+    if len(jobs) > 1:
+        print("Only one job is allowed")
+        exit(1)
     for k, v in jobs.items():
         if k == job_name:
             new_job_list.update(before)

--- a/src/gha_runner_convert/__main__.py
+++ b/src/gha_runner_convert/__main__.py
@@ -125,5 +125,5 @@ def read_file(input_file, role, region, ami, instance_type, home_dir):
     yaml.dump(data, click.get_text_stream("stdout"))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     read_file()

--- a/tests/test_gha_runner_convert.py
+++ b/tests/test_gha_runner_convert.py
@@ -1,0 +1,244 @@
+import pytest
+from gha_runner_convert.__main__ import before_job, after_job, read_file
+from collections import OrderedDict
+from click.testing import CliRunner
+from ruamel.yaml import YAML
+
+
+def test_before_job():
+    # We use OrderedDict to ensure the order of the keys
+    result = OrderedDict(
+        before_job(
+            role="test",
+            region="us-west-2",
+            ami="ami-xxxxxxxxxxxxxxxxx",
+            instance_type="t2.micro",
+            home_dir="/home/ubuntu",
+        )
+    )
+    expected = OrderedDict(
+        {
+            "start-aws-runner": {
+                "runs-on": "ubuntu-latest",
+                "permissions": {
+                    "id-token": "write",
+                    "contents": "read",
+                },
+                "outputs": {
+                    "mapping": "${{ steps.aws-start.outputs.mapping }}",
+                    "instances": "${{ steps.aws-start.outputs.instances }}",
+                },
+                "steps": [
+                    {
+                        "name": "Configure AWS credentials",
+                        "uses": "aws-actions/configure-aws-credentials@v4",
+                        "with": {
+                            "role-to-assume": "test",
+                            "aws-region": "us-west-2",
+                        },
+                    },
+                    {
+                        "name": "Start AWS runner",
+                        "id": "aws-start",
+                        "uses": "omsf-eco-infra/gha-runner@v0.3.0",
+                        "with": {
+                            "provider": "aws",
+                            "action": "start",
+                            "aws_image_id": "ami-xxxxxxxxxxxxxxxxx",
+                            "aws_instance_type": "t2.micro",
+                            "aws_region_name": "us-west-2",
+                            "aws_home_dir": "/home/ubuntu",
+                        },
+                        "env": {
+                            "GH_PAT": "${{ secrets.GH_PAT }}",
+                        },
+                    },
+                ],
+            }
+        }
+    )
+    assert result == expected
+
+
+def test_after_job():
+    result = OrderedDict(after_job("test-job", "test", "us-west-2"))
+    expected = OrderedDict(
+        {
+            "stop-aws-runner": {
+                "runs-on": "ubuntu-latest",
+                "permissions": {
+                    "id-token": "write",
+                    "contents": "read",
+                },
+                "needs": ["start-aws-runner", "test-job"],
+                "if": "${{ always() }}",
+                "steps": [
+                    {
+                        "name": "Configure AWS credentials",
+                        "uses": "aws-actions/configure-aws-credentials@v4",
+                        "with": {
+                            "role-to-assume": "test",
+                            "aws-region": "us-west-2",
+                        },
+                    },
+                    {
+                        "name": "Stop AWS runner",
+                        "uses": "omsf-eco-infra/gha-runner@v0.3.0",
+                        "with": {
+                            "provider": "aws",
+                            "action": "stop",
+                            "instance_mapping": "${{ needs.start-aws-runner.outputs.mapping }}",
+                            "aws_region_name": "us-west-2",
+                        },
+                        "env": {
+                            "GH_PAT": "${{ secrets.GH_PAT }}",
+                        },
+                    },
+                ],
+            }
+        }
+    )
+    assert result == expected
+
+
+def test_read_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        input_file = "input_action.yml"
+        with open(input_file, "w") as f:
+            f.write(
+                """
+            name: test
+            on: push
+            jobs:
+              test-job:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Test
+                    run: echo "Hello, World!"
+            """
+            )
+        result = runner.invoke(
+            read_file,
+            [
+                "--role",
+                "test",
+                "--region",
+                "us-west-2",
+                "--ami",
+                "ami-xxxxxxxxxxxxxxxxx",
+                "--instance-type",
+                "t2.micro",
+                "--home-dir",
+                "/home/ubuntu",
+                input_file,
+            ],
+        )
+        expected = """
+        name: test
+        on: push
+        jobs:
+            start-aws-runner:
+                runs-on: ubuntu-latest
+                permissions:
+                    id-token: write
+                    contents: read
+                outputs:
+                    mapping: ${{ steps.aws-start.outputs.mapping }}
+                    instances: ${{ steps.aws-start.outputs.instances }}
+                steps:
+                    - name: Configure AWS credentials
+                      uses: aws-actions/configure-aws-credentials@v4
+                      with:
+                          role-to-assume: test
+                          aws-region: us-west-2
+                    - name: Start AWS runner
+                      id: aws-start
+                      uses: omsf-eco-infra/gha-runner@v0.3.0
+                      with:
+                          provider: aws
+                          action: start
+                          aws_image_id: ami-xxxxxxxxxxxxxxxxx
+                          aws_instance_type: t2.micro
+                          aws_region_name: us-west-2
+                          aws_home_dir: /home/ubuntu
+                      env:
+                          GH_PAT: ${{ secrets.GH_PAT }}
+            test-job:
+                runs-on: ${{ fromJSON(needs.start-aws-runner.outputs.instances) }}
+                steps:
+                    - name: Test
+                      run: echo "Hello, World!"
+                needs:
+                    - start-aws-runner
+            stop-aws-runner:
+                runs-on: ubuntu-latest
+                permissions:
+                    id-token: write
+                    contents: read
+                needs:
+                    - start-aws-runner
+                    - test-job
+                if: ${{ always() }}
+                steps:
+                    - name: Configure AWS credentials
+                      uses: aws-actions/configure-aws-credentials@v4
+                      with:
+                          role-to-assume: test
+                          aws-region: us-west-2
+                    - name: Stop AWS runner
+                      uses: omsf-eco-infra/gha-runner@v0.3.0
+                      with:
+                          provider: aws
+                          action: stop
+                          instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
+                          aws_region_name: us-west-2
+                      env:
+                          GH_PAT: ${{ secrets.GH_PAT }}
+        """
+        assert result.exit_code == 0
+        yaml = YAML()
+        output = yaml.load(result.output)
+        expected = yaml.load(expected)
+        assert OrderedDict(output) == OrderedDict(expected)
+
+
+def test_read_file_fail():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        input_file = "input_action.yml"
+        with open(input_file, "w") as f:
+            f.write(
+                """
+            name: test
+            on: push
+            jobs:
+              test-job:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Test
+                    run: echo "Hello, World!"
+              test-job-2:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Test
+                    run: echo "Hello, World!" 
+            """
+            )
+        result = runner.invoke(
+            read_file,
+            [
+                "--role",
+                "test",
+                "--region",
+                "us-west-2",
+                "--ami",
+                "ami-xxxxxxxxxxxxxxxxx",
+                "--instance-type",
+                "t2.micro",
+                "--home-dir",
+                "/home/ubuntu",
+                input_file,
+            ],
+        )
+        assert result.exit_code == 1


### PR DESCRIPTION
This PR adds a CLI to take existing actions and convert them to use `gha-runner`. This does not add docs as I don't want to add them until we can agree on what options/parameters need to be provided by the user. I think docs could be added as a separate PR once this is decided.
