### PR TITLE
ci: add a formal release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,43 +34,28 @@ jobs:
         id: release-type
         run: |
           if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            echo "type=prerelease" >> "$GITHUB_OUTPUT"
+            echo "repository_url=https://test.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
+            echo "verbose=true" >> "$GITHUB_OUTPUT"
+            echo "environment_name=testpypi" >> "$GITHUB_OUTPUT"
+            echo "environment_url=https://test.pypi.org/p/gha_runner"
           else
-            echo "type=release" >> "$GITHUB_OUTPUT"
+            echo "repository_url=https://upload.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
+            echo "verbose=false" >> "$GITHUB_OUTPUT"
+            echo "environment_name=pypi" >> "$GITHUB_OUTPUT"
+            echo "environment_url=https://pypi.org/p/gha_runner"
           fi
 
-  publish-to-test-pypi:
-    name: Publish distribution to test.pypi.org
+
+  publish:
+    name: Publish distribution to ${{ needs.build.outputs.environment_name }}
     needs:
       - build
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/gha_runner
+      name: ${{ needs.build.outputs.environment_name }}
+      url: ${{ needs.build.outputs.enviuronment_url }}
     permissions:
       id-token: write
-    if: needs.build.outputs.type == 'prerelease'
-    steps:
-      - name: Download the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: gha-runner-dists
-          path: dist/
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          verbose: true
-
-  publish-to-pypi:
-    name: Publish distribution to pypi.org
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/gha_runner
-    permissions:
-      id-token: write
-    if: needs.build.outputs.type == 'release'
     steps:
       - name: Download the dists
         uses: actions/download-artifact@v4
@@ -79,3 +64,6 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ needs.build.outputs.repository_url }}
+          verbose: ${{ needs.build.outputs.verbose }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,15 +34,15 @@ jobs:
         id: release-type
         run: |
           if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            echo "repository_url=https://test.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
-            echo "verbose=true" >> "$GITHUB_OUTPUT"
-            echo "environment_name=testpypi" >> "$GITHUB_OUTPUT"
+            echo "repository_url=https://test.pypi.org/legacy/" | tee -a "$GITHUB_OUTPUT"
+            echo "verbose=true" | tee -a "$GITHUB_OUTPUT"
+            echo "environment_name=testpypi" | tee -a "$GITHUB_OUTPUT"
             echo "environment_url=https://test.pypi.org/p/gha_runner"
           else
-            echo "repository_url=https://upload.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
-            echo "verbose=false" >> "$GITHUB_OUTPUT"
-            echo "environment_name=pypi" >> "$GITHUB_OUTPUT"
-            echo "environment_url=https://pypi.org/p/gha_runner"
+            echo "repository_url=https://upload.pypi.org/legacy/" | tee -a "$GITHUB_OUTPUT"
+            echo "verbose=false" | tee -a "$GITHUB_OUTPUT"
+            echo "environment_name=pypi" | tee -a "$GITHUB_OUTPUT"
+            echo "environment_url=https://pypi.org/p/gha_runner" | tee -a "$GITHUB_OUTPUT"
           fi
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,17 @@ jobs:
         with:
           name: gha-runner-dists
           path: dist/
+      - name: Determine release type
+        id: release-type
+        run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "type=prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=release" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-to-test-pypi:
-    name: Publish distribution
+    name: Publish distribution to test.pypi.org
     needs:
       - build
     runs-on: ubuntu-latest
@@ -40,6 +49,7 @@ jobs:
       url: https://test.pypi.org/p/gha_runner
     permissions:
       id-token: write
+    if: needs.build.outputs.type == 'prerelease'
     steps:
       - name: Download the dists
         uses: actions/download-artifact@v4
@@ -51,3 +61,21 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
+
+  publish-to-pypi:
+    name: Publish distribution to pypi.org
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gha_runner
+    permissions:
+      id-token: write
+    if: needs.build.outputs.type == 'release'
+    steps:
+      - name: Download the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: gha-runner-dists
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/release.yaml` file to enhance the release process. The most important changes involve determining the release type and adding conditional steps for publishing to different PyPI repositories based on the release type. Does this look okay for this process or should we use a different process @dwhswenson?

Improvements to release process:

* Added a step to determine the release type (prerelease or release) based on the GitHub event and set the output accordingly.
* Updated the `publish-to-test-pypi` job to only run if the release type is `prerelease`.
* Added a new job `publish-to-pypi` to publish the distribution to `pypi.org` if the release type is `release`.