### PR TITLE
ci: add weekly builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ on:
       - ".github/**"
       - "docs/**"
       - "README.md"
+  schedule:
+    - cron: "0 13 * * 1" # 1300 UTC on Mondays
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds a weekly run to validate against anything that fails. In the future we may add running the larger integration tests too.
