### PR TITLE
Fix "identity provider" URL typo

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -43,7 +43,7 @@ The goal of this document is to provide a guide on how to set up the GitHub Acti
   2. Go to the IAM Console.
   3. In the navigation pane, select "Roles" and then click "Create Role".
   4. Select "Web Identity" for the trusted entity type.
-  5. Set your identity provider to "tokens.actions.githubusercontent.com"
+  5. Set your identity provider to "token.actions.githubusercontent.com"
   6. Set the audience to `sts.amazonaws.com`
   7. Set your GitHub auth rules:
       - GitHub organization - This would be your org or username for example, `omsf-eco-infra`. This limits it so that credentials are only given to this organization.


### PR DESCRIPTION
I think it's supposed to be `token.actions.githubusercontent.com` ("token" singular, not "tokens").

The [Set up the OpenID Connect (OIDC) Provider](https://github.com/omsf/gha-runner/blob/main/docs/aws.md#set-up-the-openid-connect-oidc-provider) section uses "token", and [Obtain the thumbprint for an OIDC identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html) AWS docs only work with `token`, not `tokens`:

```console
$ curl -s https://tokens.actions.githubusercontent.com/.well-known/openid-configuration
<h2>Our services aren't available right now</h2><p>We're working to restore all services as soon as possible. Please check back soon.</p>0zTFxaAAAAAAZ6BJm6jmt^C
$ curl -s https://token.actions.githubusercontent.com/.well-known/openid-configuration | jq -r .jwks_uri
https://token.actions.githubusercontent.com/.well-known/jwks
```