### PR TITLE
Include HTTP status in GitHub API errors

### DIFF
--- a/src/gha_runner/gh.py
+++ b/src/gha_runner/gh.py
@@ -92,7 +92,8 @@ class GitHubInstance:
         resp: requests.Response = func(endpoint_url, headers=headers, **kwargs)
         if not resp.ok:
             raise RuntimeError(
-                f"Error in API call for {endpoint_url}: " f"{resp.content}"
+                f"Error in API call for {endpoint_url}: "
+                f"{resp.status_code} {resp.reason}: {resp.content}"
             )
         else:
             try:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -129,9 +129,16 @@ def test_get_runners_error(github_instance):
     responses.add(
         responses.GET,
         "https://api.github.com/repos/test/test/actions/runners",
+        body="server unavailable",
         status=500,
     )
-    with pytest.raises(RunnerListError, match="Error getting runners: *"):
+    with pytest.raises(
+        RunnerListError,
+        match=(
+            "Error getting runners: Error in API call for .*: "
+            "500 Internal Server Error: b'server unavailable'"
+        ),
+    ):
         github_instance.get_runners()
 
 


### PR DESCRIPTION
I was having what I think was a [transient error](https://github.com/m2lines/Samudra/actions/runs/28870222236/job/85630712628) during fetching runners which only showed an empty body:

```
gha_runner.gh.RunnerListError: Error getting runners: Error in API call for https://api.github.com/repos/m2lines/Samudra/actions/runners?per_page=30&page=1: b''
```


This PR adds the status line/number to make it easier to track down this kind of thing. We could alternatively consider using resp.raise_for_status() rather than a RuntimeException but that will not show the body content (not sure which is more useful generally for GitHub API errors)